### PR TITLE
Improve environment configuration property naming

### DIFF
--- a/GitVersion.yml
+++ b/GitVersion.yml
@@ -14,5 +14,5 @@ branches:
     - feature
     - support
     - hotfix
-next-version: "1.0"
+next-version: "2.0"
 

--- a/HELP.md
+++ b/HELP.md
@@ -1,5 +1,6 @@
 # ZeroFailed.Deploy.Common - Reference Sheet
 
+
 <!-- START_GENERATED_HELP -->
 
 ## Configuration
@@ -8,16 +9,31 @@ This group contains functionality for interacting with configuration used as par
 
 ### Properties
 
-| Name                    | Default Value | ENV Override                        | Description                                                                             |
-| ----------------------- | ------------- | ----------------------------------- | --------------------------------------------------------------------------------------- |
-| `ConfigPath`            | "./config"    | `ZF_DEPLOY_CONFIG_PATH`             | The path to the folder containing  deployment configuration files for the environments. |
-| `SkipReadConfiguration` | $false        | `ZF_DEPLOY_SKIP_READ_CONFIGURATION` | When true, the deployment configuration will not be processed.                          |
+| Name | Default Value | ENV Override | Description |
+|------|---------------|--------------|-------------|
+| `EnvironmentConfigName` | N/A | `ZF_DEPLOY_ENVIRONMENT_CONFIG_NAME` | Use this to override the name of the file containing the configuration settings for the target environment, when it isn't the same as the environment name. |
+| `EnvironmentConfigPath` | N/A | `ZF_DEPLOY_ENVIRONMENT_CONFIG_PATH` | The path to the folder containing  deployment configuration files for the environments. |
+| `EnvironmentName` | N/A | `ZF_DEPLOY_ENVIRONMENT_NAME` | The name of the environment that is the target of the deployment. Typically this matches the filename containing the configuration settings for this environment. |
+| `SkipReadConfiguration` | $false | `ZF_DEPLOY_SKIP_READ_CONFIGURATION` | When true, the deployment configuration will not be processed. |
 
 ### Tasks
 
-| Name                | Description                                                                                                         |
-| ------------------- | ------------------------------------------------------------------------------------------------------------------- |
+| Name | Description |
+|------|-------------|
 | `readConfiguration` | Parses the specified environment's configuration, using the Corvus.Deployment conventions, from the specified path. |
+
+## Deploy.process
+
+This group contains properties affecting the behaviour of the logical deployment process.
+
+### Properties
+
+| Name | Default Value | ENV Override | Description |
+|------|---------------|--------------|-------------|
+| `SkipDeploy` | $false | `ZF_DEPLOY_SKIP_DEPLOY` | When true, the 'Deploy' stage of the deployment process will not be run |
+| `SkipInit` | $false | `ZF_DEPLOY_SKIP_INIT` | When true, the 'Init' stage of the deployment process will not be run |
+| `SkipProvision` | $false | `ZF_DEPLOY_SKIP_PROVISION` | When true, the 'Provision' stage of the deployment process will not be run |
+| `SkipTest` | $false | `ZF_DEPLOY_SKIP_TEST` | When true, the 'Test' stage of the deployment process will not be run |
 
 
 <!-- END_GENERATED_HELP -->

--- a/module/tasks/configuration.properties.ps1
+++ b/module/tasks/configuration.properties.ps1
@@ -8,10 +8,10 @@ $DeploymentConfig = @{}
 $SkipReadConfiguration = [Convert]::ToBoolean((property ZF_DEPLOY_SKIP_READ_CONFIGURATION $false))
 
 # Synopsis: The path to the folder containing  deployment configuration files for the environments.
-$EnvironmentConfigPath ??= property ZF_DEPLOY_ENVIRONMENT_CONFIG_PATH ((Test-Path variable:/here) ? (Join-Path $here "config") : "./config")
+$EnvironmentConfigPath = [string]::IsNullOrEmpty($EnvironmentConfigPath) ? (property ZF_DEPLOY_ENVIRONMENT_CONFIG_PATH ((Test-Path variable:/here) ? (Join-Path $here "config") : "./config")) : $EnvironmentConfigPath
 
 # Synopsis: The name of the environment that is the target of the deployment. Typically this matches the filename containing the configuration settings for this environment.
-$EnvironmentName ??= property ZF_DEPLOY_ENVIRONMENT_NAME ''
+$EnvironmentName = [string]::IsNullOrEmpty($EnvironmentName) ? (property ZF_DEPLOY_ENVIRONMENT_NAME '') : $EnvironmentName
 
 # Synopsis: Use this to override the name of the file containing the configuration settings for the target environment, when it isn't the same as the environment name.
-$EnvironmentConfigName ??= property ZF_DEPLOY_ENVIRONMENT_CONFIG_NAME $EnvironmentName
+$EnvironmentConfigName = [string]::IsNullOrEmpty($EnvironmentConfigName) ? (property ZF_DEPLOY_ENVIRONMENT_CONFIG_NAME $EnvironmentName) : $EnvironmentConfigName

--- a/module/tasks/configuration.properties.ps1
+++ b/module/tasks/configuration.properties.ps1
@@ -8,4 +8,10 @@ $DeploymentConfig = @{}
 $SkipReadConfiguration = [Convert]::ToBoolean((property ZF_DEPLOY_SKIP_READ_CONFIGURATION $false))
 
 # Synopsis: The path to the folder containing  deployment configuration files for the environments.
-$ConfigPath = property ZF_DEPLOY_CONFIG_PATH ((Test-Path variable:/here) ? (Join-Path $here "config") : "./config")
+$EnvironmentConfigPath ??= property ZF_DEPLOY_ENVIRONMENT_CONFIG_PATH ((Test-Path variable:/here) ? (Join-Path $here "config") : "./config")
+
+# Synopsis: The name of the environment that is the target of the deployment. Typically this matches the filename containing the configuration settings for this environment.
+$EnvironmentName ??= property ZF_DEPLOY_ENVIRONMENT_NAME ''
+
+# Synopsis: Use this to override the name of the file containing the configuration settings for the target environment, when it isn't the same as the environment name.
+$EnvironmentConfigName ??= property ZF_DEPLOY_ENVIRONMENT_CONFIG_NAME $EnvironmentName

--- a/module/tasks/configuration.tasks.ps1
+++ b/module/tasks/configuration.tasks.ps1
@@ -20,6 +20,6 @@ task ensureCorvusDeploymentModule -If { !$SkipReadConfiguration } -Before setupM
 task readConfiguration -If { !$SkipReadConfiguration } -After InitCore ensureCorvusDeploymentModule,setupModules,{
 
     $script:DeploymentConfig = Read-CorvusDeploymentConfig `
-                                    -ConfigPath $ConfigPath  `
+                                    -ConfigPath $EnvironmentConfigPath  `
                                     -EnvironmentConfigName $EnvironmentConfigName
 }

--- a/module/tasks/deploy.process.properties.ps1
+++ b/module/tasks/deploy.process.properties.ps1
@@ -1,0 +1,15 @@
+# <copyright file="deploy.process.properties.ps1" company="Endjin Limited">
+# Copyright (c) Endjin Limited. All rights reserved.
+# </copyright>
+
+# Synopsis: When true, the 'Init' stage of the deployment process will not be run
+$SkipInit = [Convert]::ToBoolean((property ZF_DEPLOY_SKIP_INIT $false))
+
+# Synopsis: When true, the 'Provision' stage of the deployment process will not be run
+$SkipProvision = [Convert]::ToBoolean((property ZF_DEPLOY_SKIP_PROVISION $false))
+
+# Synopsis: When true, the 'Deploy' stage of the deployment process will not be run
+$SkipDeploy = [Convert]::ToBoolean((property ZF_DEPLOY_SKIP_DEPLOY $false))
+
+# Synopsis: When true, the 'Test' stage of the deployment process will not be run
+$SkipTest = [Convert]::ToBoolean((property ZF_DEPLOY_SKIP_TEST $false))

--- a/module/tasks/deploy.process.ps1
+++ b/module/tasks/deploy.process.ps1
@@ -2,11 +2,7 @@
 # Copyright (c) Endjin Limited. All rights reserved.
 # </copyright>
 
-# Top-level deployment process control flags
-$SkipInit = property ZF_DEPLOY_SKIP_INIT $false
-$SkipProvision = property ZF_DEPLOY_SKIP_PROVISION $false
-$SkipDeploy = property ZF_DEPLOY_SKIP_DEPLOY $false
-$SkipTest = property ZF_DEPLOY_SKIP_TEST $false
+. $PSScriptRoot/deploy.process.properties.ps1
 
 # Define a logical deployment process that extensions can attach to
 


### PR DESCRIPTION
Breaking Change:
- `ConfigPath` renamed to `EnvironmentConfigPath`, due to it being too generic and inconsistent with other related properties

Other Changes:
- Added some missing environment configuration-related properties
- Consistency pass on process-level properties